### PR TITLE
fix issue with nil pointer in http handler

### DIFF
--- a/pkg/upload/upload.go
+++ b/pkg/upload/upload.go
@@ -25,6 +25,9 @@ type partChannelClient struct {
 
 func (c *partChannelClient) Do(r *http.Request) (*http.Response, error) {
 	resp, err := c.HTTPClient.Do(r)
+	if err != nil {
+		return resp, err
+	}
 	partNumber := r.URL.Query().Get("partNumber")
 	if resp.StatusCode < 400 && r.Method == "PUT" && partNumber != "" {
 		partNumber, _ := strconv.ParseInt(partNumber, 10, 64)


### PR DESCRIPTION
This is very hard to test but I am 99% sure this is the problem. At first I thought it was in the library but I pass this method into the library and the library calls it so it looked like it was coming from the library. The stack trace points to this line:

```go
	if resp.StatusCode < 400 && r.Method == "PUT" && partNumber != "" {
```

With a de-referencing `nil` panic. This means that `resp` must be `nil`. That comes directly from the http client:

```go
resp, err := c.HTTPClient.Do(r)
```

At the bottom of the function I return `resp` and `err`, however if the client encountered an error the `resp` may be `nil` but I access it before the return. `resp` should only be `nil` if error is not `nil` so this should fix that case. However, this means that some sort of HTTP error may have been encountered. There is some degree of retry. This will make the error more sensible at the very least.