### PR TITLE
[SC-172047] Change "idseq" references in cli_user_instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# IDSeq CLI
+# CZ ID CLI
 
 This project is under active development and in its beta phase. It should be fairly stable but there may be some issues. If you experience an issue please [let us know](https://github.com/chanzuckerberg/idseq-cli-v2/issues).
 
-A **C**ommand **L**ine **I**nterface for [IDSeq](https://idseq.net/). 
+A **C**ommand **L**ine **I**nterface for [CZ ID](https://czid.org/). 
 
 Rewrite of https://github.com/chanzuckerberg/idseq-cli.
 
@@ -80,13 +80,13 @@ Note on MacOS: Currently we don't sign our binary so you will need to manually r
 
 #### Setup
 
-First log in with your IDSeq account:
+First log in with your CZ ID account:
 
 ```bash
 idseq login
 ```
 
-You will be prompted to log in with your IDSeq account via the web.
+You will be prompted to log in with your CZ ID account via the web.
 
 Accept the user agreement:
 
@@ -98,17 +98,17 @@ This will print the user agreement and prompt you for your agreement.
 
 #### Upload a Single Sample
 
-You can use the IDSeq CLI to upload samples to upload a single sample to IDSeq. You can upload a single file for single end reads or two files for paired end reads. Supported file types: `.fastq`/`.fq`/`.fasta`/`.fa`/`.fastq.gz`/`.fq.gz`/`.fasta.gz`/`.fa.gz`.
+You can use the CZ ID CLI to upload samples to upload a single sample to CZ ID. You can upload a single file for single end reads or two files for paired end reads. Supported file types: `.fastq`/`.fq`/`.fasta`/`.fa`/`.fastq.gz`/`.fq.gz`/`.fasta.gz`/`.fa.gz`.
 
 Optionally, you can create a metadata CSV file for your sample. You can skip this step and specify your metadata with command line flags. For instructions on creating this file see:
 
-- Instructions: https://idseq.net/metadata/instructions
-- Metadata dictionary and supported host genomes: https://idseq.net/metadata/dictionary
-- Metadata CSV template: https://idseq.net/metadata/metadata_template_csv
+- Instructions: https://czid.org/metadata/instructions
+- Metadata dictionary and supported host genomes: https://czid.org/metadata/dictionary
+- Metadata CSV template: https://czid.org/metadata/metadata_template_csv
 
 Be sure to set the sample name in the `Sample Name` column of the CSV to the same name you pass to the `upload-sample` command with `-s`/`--sample-name`. If you would like to specify your metadata entirely with `-m` flags you don't need to include a `--metadata-csv`. If you have specified all of your metadata in the metadata csv you don't need to include any `-m` flags. `-m` flags override metadata from the csv.
 
-Once you have set up you can use the `upload-sample` command to upload your sample to IDSeq.
+Once you have set up you can use the `upload-sample` command to upload your sample to CZ ID.
 
 Linux + MacOS:
 
@@ -136,7 +136,7 @@ Note: The sample name is optional. If it is not included it will be computed fro
 
 #### Upload Multiple Samples
 
-The IDSeq CLI can search a directory for read files and upload supported files as samples. Supported file types are: `.fastq`/`.fq`/`.fasta`/`.fa`/`.fastq.gz`/`.fq.gz`/`.fasta.gz`/`.fa.gz`. Sample names are computed based on the names of the files. Sample names the base name of the file with the extension, `_R1`, `_R2`, `_R1_001`, and `_R2_001` removed. If two files have the same sample name and one has `R1` and the other has `R2` the files will be uploaded to the same sample as paired reads. Since only the base name of the file and no parent directories are taken into account file names must be globally unique (except for the same sample's `R1` and `R2` files). Here are a few examples of sample names for various paths:
+The CZ ID CLI can search a directory for read files and upload supported files as samples. Supported file types are: `.fastq`/`.fq`/`.fasta`/`.fa`/`.fastq.gz`/`.fq.gz`/`.fasta.gz`/`.fa.gz`. Sample names are computed based on the names of the files. Sample names the base name of the file with the extension, `_R1`, `_R2`, `_R1_001`, and `_R2_001` removed. If two files have the same sample name and one has `R1` and the other has `R2` the files will be uploaded to the same sample as paired reads. Since only the base name of the file and no parent directories are taken into account file names must be globally unique (except for the same sample's `R1` and `R2` files). Here are a few examples of sample names for various paths:
 
 - `your_directory_of_samples/my_sample.fasta` => `my_sample`
 - `your_directory_of_samples/sample_one/sample_one_R1.fastq.gz` => `sample_one`
@@ -147,13 +147,13 @@ This is the first pass of directory uploads and we would like to support more di
 
 Optionally, you can create a metadata CSV file for your sample. You can skip this step and specify your metadata with command line flags. For instructions on creating this file see:
 
-- Instructions: https://idseq.net/metadata/instructions
-- Metadata dictionary and supported host genomes: https://idseq.net/metadata/dictionary
-- Metadata CSV template: https://idseq.net/metadata/metadata_template_csv
+- Instructions: https://czid.org/metadata/instructions
+- Metadata dictionary and supported host genomes: https://czid.org/metadata/dictionary
+- Metadata CSV template: https://czid.org/metadata/metadata_template_csv
 
 To associate a row of metadata with a sample you must enter the correct sample name in the `Sample Name` column of the CSV. If you would like to specify your metadata entirely with `-m` flags you don't need to include a `--metadata-csv`. If you have specified all of your metadata in the metadata csv you don't need to include any `-m` flags. `-m` flags override metadata from the csv.
 
-Once you have set up you can use the `upload-samples` command to upload your directory to IDSeq.
+Once you have set up you can use the `upload-samples` command to upload your directory to CZ ID.
 
 Linux + MacOS:
 
@@ -181,7 +181,7 @@ idseq-cli-v2 can be configured with environment variables or files. By default c
 
 ### Configuration Options
 
-- `secret`: a secret used to persistently authenticate with IDSeq. Generated by running: `idseq login --persistent`
+- `secret`: a secret used to persistently authenticate with CZ ID. Generated by running: `idseq login --persistent`
 - `accepted_user_agreement`: set to `Y` if the user has accepted the user agreement. Setting this manually means you accept the user agreement. Also set via: `idseq accept-user-agreement`
 
 ## Differences from version 1
@@ -191,19 +191,19 @@ idseq-cli-v2 can be configured with environment variables or files. By default c
 - Distributed as a single binary for easier installation that doesn't rely on dependencies on the user's machine
 - Shell completion support
 - Structured with commands and subcommands to make room for future functionality
-- Log in in the web via your IDSeq account instead of using a static token
+- Log in in the web via your CZ ID account instead of using a static token
 - Critical bugfixes
 - Uploads without the need for user prompts
 - Supports configuration files and environment variable configuration instead of relying solely on flags
 
 ## Contributing
 
-This project is not seeking contributions at this time. It is tighly coupled to the IDSeq Web App, it's features, it's APIs, and it's development goals. Please feel free to raise issues for feature requests or bugs.
+This project is not seeking contributions at this time. It is tighly coupled to the CZ ID Web App, it's features, it's APIs, and it's development goals. Please feel free to raise issues for feature requests or bugs.
 
 This project adheres to the Contributor Covenant [code of conduct](https://www.contributor-covenant.org/). By participating, you are expected to uphold this code. Please report unacceptable behavior to opensource@chanzuckerberg.com.
 
 ## Reporting Security Issues
 
-Please note: If you believe you have found a security issue, please responsibly disclose by contacting us at security@idseq.net.
+Please note: If you believe you have found a security issue, please responsibly disclose by contacting us at security@czid.org.
 
 See [SECURITY.md](SECURITY.md) for more information.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,6 @@ This project adheres to the Contributor Covenant [code of conduct](https://www.c
 
 ## Reporting Security Issues
 
-Please note: If you believe you have found a security issue, please responsibly disclose by contacting us at security@czid.org.
+Please note: If you believe you have found a security issue, please responsibly disclose by contacting us at security@idseq.net.
 
 See [SECURITY.md](SECURITY.md) for more information.


### PR DESCRIPTION
# Description
Change all "idseq" references to the new rebranded name in https://czid.org/cli_user_instructions

# Notes
This does not include:
* renaming idseq-cli-v2 repo
* changing idseq references in cli commands

The above changes will be included in a follow-up PR, documented by [[SC-171444]](https://app.shortcut.com/idseq/story/171444/rebrand-idseq-cli-v2)

Confirmed with Olivia: All IDseq instances should be changed to CZ ID.

# Tests